### PR TITLE
MOEN-18590: Fixed the issue where custom attribute true/false is trac…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # ChangeLog:
 =================================
+# Next Release Date
+
+## PluginBase 5.0.0
+-------------------------------------------
+* BugFix -  Fixed the issue where custom attribute true/false is tracked as 1/0. 
+* Updated the dependency to MoEngage-iOS-SDK `9.18.1`.
+
+## Cards 2.0.0
+-------------------------------------------
+* Updated the dependency to PluginBase `5.0.0`.
+
+## Inbox 3.0.0
+-------------------------------------------
+* Updated the dependency to PluginBase `5.0.0`.
+
+## Geofence 3.0.0
+-------------------------------------------
+* Updated the dependency to PluginBase `5.0.0`.
+
 # 31-07-2024
 
 ## PluginBase 4.10.0

--- a/MoEngagePluginBase.podspec
+++ b/MoEngagePluginBase.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = 'MoEngagePluginBase'
-    s.version      = '4.10.0'
+    s.version      = '5.0.0'
     s.summary      = 'MoEngage Plugin Base for Hybrid SDKs'
     s.description  = <<-DESC
     MoEngage is a mobile marketing automation company. This framework is used by our plugins built for different hybrid frameworks i.e, Flutter, Cordova, React Native etc.
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
     s.source_files = 'MoEngagePluginBase/**/*'
     s.swift_version = '5.0'
     s.frameworks = 'UIKit', 'Foundation', 'UserNotifications'
-    s.dependency 'MoEngage-iOS-SDK', '>= 9.18.0', '< 9.19.0'
+    s.dependency 'MoEngage-iOS-SDK', '9.18.1'
     s.dependency 'MoEngage-iOS-SDK/InApps'
 end

--- a/MoEngagePluginBase/MoEngageAnalyticsConfig.swift
+++ b/MoEngagePluginBase/MoEngageAnalyticsConfig.swift
@@ -1,0 +1,16 @@
+//
+//  MoEngageAnalyticsConfig.swift
+//  MoEngagePluginBase
+//
+//  Created by UdayKiran Naik on 02/07/24.
+//
+
+import Foundation
+
+class MoEngageAnalyticsConfig {
+    var shouldTrackUserAttributeBooleanAsNumber: Bool
+    
+    init(shouldTrackUserAttributeBooleanAsNumber: Bool) {
+        self.shouldTrackUserAttributeBooleanAsNumber = shouldTrackUserAttributeBooleanAsNumber
+    }
+}

--- a/MoEngagePluginBase/MoEngageInitConfig.swift
+++ b/MoEngagePluginBase/MoEngageInitConfig.swift
@@ -1,0 +1,16 @@
+//
+//  MoEngageInitConfig.swift
+//  MoEngagePluginBase
+//
+//  Created by UdayKiran Naik on 02/07/24.
+//
+
+import Foundation
+
+class MoEngageInitConfig {
+    var analyticsConfig: MoEngageAnalyticsConfig
+    
+    init(analyticsConfig: MoEngageAnalyticsConfig) {
+        self.analyticsConfig = analyticsConfig
+    }
+}

--- a/MoEngagePluginBase/MoEngageInitConfigCache.swift
+++ b/MoEngagePluginBase/MoEngageInitConfigCache.swift
@@ -1,0 +1,34 @@
+//
+//  MoEngageHybridToNativeConfig.swift
+//  MoEngagePluginBase
+//
+//  Created by UdayKiran Naik on 02/07/24.
+//
+
+import Foundation
+
+public class MoEngageInitConfigCache {
+    public static let sharedInstance = MoEngageInitConfigCache()
+    private var initConfigCache: [String:MoEngageInitConfig] = [:]
+    
+    private init() {
+        
+    }
+    
+    func initializeInitConfig(appID: String, initConfig: MoEngageInitConfig) {
+        if(initConfigCache.keys.contains(appID)) {
+            return
+        }
+        
+        self.initConfigCache[appID] = initConfig
+    }
+    
+    func fetchShouldTrackUserAttributeBooleanAsNumber(forAppID: String)->Bool {
+        guard let initConfig = initConfigCache[forAppID] else {
+            return false
+        }
+        
+        return initConfig.analyticsConfig.shouldTrackUserAttributeBooleanAsNumber
+    }
+    
+}

--- a/MoEngagePluginBase/MoEngagePluginConstants.swift
+++ b/MoEngagePluginBase/MoEngagePluginConstants.swift
@@ -31,6 +31,7 @@ public struct MoEngagePluginConstants {
         public static let navigationType = "navigationType"
         public static let actionType = "actionType"
         public static let type = "type"
+        public static let initConfig = "initConfig"
         static let appId = "appId"
         static let campaignName = "campaignName"
         static let event = "event"
@@ -38,6 +39,8 @@ public struct MoEngagePluginConstants {
         static let integrationMeta = "integrationMeta"
         static let integrationType = "type"
         static let integrationVersion = "version"
+        public static let analyticsConfig = "analyticsConfig"
+        public static let shouldTrackUserAttributeBooleanAsNumber = "shouldTrackUserAttributeBooleanAsNumber"
     }
     
     // user attribute

--- a/MoEngagePluginBase/MoEngagePluginUtils.swift
+++ b/MoEngagePluginBase/MoEngagePluginUtils.swift
@@ -22,6 +22,15 @@ public class MoEngagePluginUtils {
         return nil
     }
     
+    static func fetchInitConfig(attribute: [String:Any]) -> MoEngageInitConfig? {
+        if let initConfig = attribute[MoEngagePluginConstants.General.initConfig] as? [String:Any],
+           let analyticsConfig = initConfig[MoEngagePluginConstants.General.analyticsConfig] as? [String:Any],
+           let shouldTrackUserAttributeBooleanAsNumber = analyticsConfig[MoEngagePluginConstants.General.shouldTrackUserAttributeBooleanAsNumber] as? Bool{
+            return MoEngageInitConfig(analyticsConfig: MoEngageAnalyticsConfig(shouldTrackUserAttributeBooleanAsNumber: shouldTrackUserAttributeBooleanAsNumber))
+        }
+        return nil
+    }
+
     static public func createAccountPayload(identifier: String) -> [String: Any] {
         let appIdDict = [MoEngagePluginConstants.General.appId: identifier]
         return appIdDict

--- a/MoEngagePluginCards.podspec
+++ b/MoEngagePluginCards.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = 'MoEngagePluginCards'
-    s.version      = '1.7.0'
+    s.version      = '2.0.0'
     s.summary      = 'MoEngage Cards Plugin for Hybrid SDKs'
     s.description  = <<-DESC
     MoEngage is a mobile marketing automation company. This framework is used by our plugins built for different hybrid frameworks i.e, Flutter, Cordova, React Native etc.
@@ -22,7 +22,7 @@ Pod::Spec.new do |s|
     s.source_files = 'MoEngagePluginCards/**/*'
     s.swift_version = '5.0'
     s.frameworks = 'UIKit', 'Foundation', 'UserNotifications'
-    s.dependency 'MoEngagePluginBase', '>= 4.10.0', '< 4.11.0'
+    s.dependency 'MoEngagePluginBase', '5.0.0'
     s.dependency 'MoEngage-iOS-SDK/Cards'
 
     # s.test_spec 'UnitTests' do |ts|

--- a/MoEngagePluginGeofence.podspec
+++ b/MoEngagePluginGeofence.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = 'MoEngagePluginGeofence'
-    s.version      = '2.10.0'
+    s.version      = '3.0.0'
     s.summary      = 'MoEngage Plugin Base for Hybrid SDKs'
     s.description  = <<-DESC
     MoEngage is a mobile marketing automation company. This framework is used by our plugins built for different hybrid frameworks i.e, Flutter, Cordova, React Native etc.
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
     s.source_files = 'MoEngagePluginGeofence/**/*'
     s.swift_version = '5.0'
     s.frameworks = 'UIKit', 'Foundation', 'UserNotifications'
-    s.dependency 'MoEngagePluginBase', '>= 4.10.0', '< 4.11.0'
     s.dependency 'MoEngage-iOS-SDK/GeoFence'
+    s.dependency 'MoEngagePluginBase', '5.0.0'
 end

--- a/MoEngagePluginInbox.podspec
+++ b/MoEngagePluginInbox.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name         = 'MoEngagePluginInbox'
-    s.version      = '2.10.0'
+    s.version      = '3.0.0'
     s.summary      = 'MoEngage Plugin Base for Hybrid SDKs'
     s.description  = <<-DESC
     MoEngage is a mobile marketing automation company. This framework is used by our plugins built for different hybrid frameworks i.e, Flutter, Cordova, React Native etc.
@@ -22,6 +22,6 @@ Pod::Spec.new do |s|
     s.source_files = 'MoEngagePluginInbox/**/*'
     s.swift_version = '5.0'
     s.frameworks = 'UIKit', 'Foundation', 'UserNotifications'
-    s.dependency 'MoEngagePluginBase', '>= 4.10.0', '< 4.11.0'
+    s.dependency 'MoEngagePluginBase', '5.0.0'
     s.dependency 'MoEngage-iOS-SDK/Inbox'
 end


### PR DESCRIPTION
…ked as 1/0 (#37)

* MOEN-18590: Fixed the issue where custom attribute true/false is tracked as 1/0.

* MOEN-18590: Updated versions

* MOEN-32294: Boolean User Attribute tracked as 0/1 instead of T/F fix. (#38)

* Boolean User Attribute Changes

* Addressed Comments

* Added check for appID in fetching shouldTrackUserAttributeBooleanAsNumber method.

* Cached initialization config when multi instances are initialized

* Addresses 1st round of comments

* Addressed 2nd round of comments

* Changed Model Classes from Public to Internal

* MOEN-18590: User attribute true/false fix with sdk version 9.15.0

* MOEN-18590: Mapped to double instead of int

* made structure variables to public from internal

* MOEN-18590: Updated podspec dependency

* MOEN-18590: Updated Inapps dependency name

* MOEN-18590: Updated dependency

* MOEN-33421: Pinned iOS versions

---------