### PR TITLE
MOEN-35320: Fixed the compiler issue in TV target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog:
 =================================
+# Next Release
+
+## PluginBase
+-------------------------------------------
+* Fixed the compiler issue in TV target due to the attribute check in `registerForProvisionalPush` method.
+  
 # 26-09-2024
 
 ## PluginBase 5.1.0

--- a/MoEngagePluginBase/MoEngagePluginBridge.swift
+++ b/MoEngagePluginBase/MoEngagePluginBridge.swift
@@ -205,7 +205,6 @@ import MoEngageInApps
         #endif
     }
     
-    @available(tvOS, unavailable)
     @available(iOS 12.0, *)
     @objc public func registerForProvisionalPush() {
         #if os(tvOS)


### PR DESCRIPTION
https://moengagetrial.atlassian.net/browse/MOEN-35320

Fixed the compiler issue in TV target due to the attribute check in `registerForProvisionalPush` method.