### PR TITLE
MOEN-46338: Support MoEngage iOS SDK 11.0.0 (Swift concurrency)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Release Date
+
+## Release Version
+
+- [minor] MOEN-46338: Added support for the MoEngage iOS SDK 11.0.0 major release (Swift concurrency migration)
+- [major] Updated MoEngage-iOS-SDK to 11.00.0
+
 # 01-07-2026
 
 ## 6.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Release Version
 
-- [minor] MOEN-46338: Added support for the MoEngage iOS SDK 11.0.0 major release (Swift concurrency migration)
+- [minor] Added support for the MoEngage iOS SDK 11.0.0 major release (Swift concurrency migration)
 - [major] Updated MoEngage-iOS-SDK to 11.00.0
 
 # 01-07-2026

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/moengage/apple-sdk.git", exact: "10.14.0")
+        .package(url: "https://github.com/moengage/apple-sdk.git", exact: "11.00.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.

--- a/Sources/MoEngagePluginBase/MoEngagePlugin.swift
+++ b/Sources/MoEngagePluginBase/MoEngagePlugin.swift
@@ -127,7 +127,10 @@ extension MoEngagePlugin: MoEngageModule.Item {
     static let context: MoEngageSynchronizationContext = "com.moengage.pluginBase"
 
     public static func getInfo(sdkInstance: isolated MoEngageSDKInstance) -> MoEngageModule.Info? {
-        return MoEngageModule.Info(identity: .init(name: "pluginBase", version: MoEngagePluginConstants.version))
+        // Return a nil identity so PluginBase is not
+        // reported in the backend `integratedModules` payload
+        // The hybrid integration + version is reported separately via `trackPluginInfo`.
+        return MoEngageModule.Info(identity: nil)
     }
 
     public static func process(event: MoEngageModule.Event, sdkInstance: isolated MoEngageSDKInstance) {

--- a/Sources/MoEngagePluginBase/MoEngagePlugin.swift
+++ b/Sources/MoEngagePluginBase/MoEngagePlugin.swift
@@ -47,13 +47,13 @@ import MoEngageInApps
         }
 
         guard
-            let sdkConfig = try? MoEngageInitialization.fetchSDKConfigurationFromInfoPlist(),
-            !sdkConfig.appId.isEmpty
+            let sdkConfigData = try? MoEngageConfig.FileBased.fetchSDKConfigurationFromInfoPlist(),
+            !sdkConfigData.workspaceId.isEmpty
         else {
             MoEngageLogger.logDefault(message: "App ID is empty. Please provide a valid App ID to setup the SDK.")
             return nil
         }
-        return sdkConfig
+        return sdkConfigData.asSdkConfig
     }
 
     // MARK: Initialization of default instance
@@ -126,19 +126,27 @@ import MoEngageInApps
 extension MoEngagePlugin: MoEngageModule.Item {
     static let context: MoEngageSynchronizationContext = "com.moengage.pluginBase"
 
-    public static func getInfo(sdkInstance: MoEngageSDKInstance) -> MoEngageModule.Info {
-        return .init(name: "pluginBase", version: MoEngagePluginConstants.version)
+    public static func getInfo(sdkInstance: isolated MoEngageSDKInstance) -> MoEngageModule.Info? {
+        return MoEngageModule.Info(identity: .init(name: "pluginBase", version: MoEngagePluginConstants.version))
     }
 
-    public static func process(event: MoEngageModule.Event, sdkInstance: MoEngageSDKInstance) {
+    public static func process(event: MoEngageModule.Event, sdkInstance: isolated MoEngageSDKInstance) {
         context.execute {
             switch event {
             case .`init`:
-                Self.setDelegates(identifier: sdkInstance.sdkConfig.appId)
+                Self.setDelegates(identifier: sdkInstance.config.workspaceId)
             default:
                 break
             }
         }
+    }
+
+    public static func process(event: MoEngageModule.AsyncEvent, sdkInstance: isolated MoEngageSDKInstance) async {
+        // MoEngagePluginBase has no asynchronous lifecycle work.
+    }
+
+    public static func listensToAdditionalNotifications() -> [Notification.Name] {
+        return []
     }
 
     private static func setDelegates(identifier: String) {
@@ -147,7 +155,11 @@ extension MoEngagePlugin: MoEngageModule.Item {
         MoEngageLogger.logDefault(message: "MoEngagePluginMessageDelegateHandler is unavailable for tvOS 🛑")
 #else
     _ = MoEngagePluginMessageDelegateHandler(identifier: identifier)
-    _ = MoEngagePluginAuthenticationListenerHandler(identifier: identifier)
+    // `MoEngageAuthenticationError.Listener` is `@MainActor` isolated in SDK 11, so the
+    // conforming handler must be instantiated on the main actor.
+    Task { @MainActor in
+        _ = MoEngagePluginAuthenticationListenerHandler(identifier: identifier)
+    }
 #endif
         MoEngagePluginBaseHandler.initializePluginBridge(className: MoEngagePluginConstants.ExternalPluginBase.cardsBridge)
     }

--- a/Sources/MoEngagePluginBase/MoEngagePluginAuthenticationListenerHandler.swift
+++ b/Sources/MoEngagePluginBase/MoEngagePluginAuthenticationListenerHandler.swift
@@ -8,6 +8,7 @@ import MoEngageSDK
 
 
 @available(iOSApplicationExtension, unavailable)
+@MainActor
 final class MoEngagePluginAuthenticationListenerHandler: NSObject, MoEngageAuthenticationError.Listener {
 
     private let  identifier: String

--- a/Sources/MoEngagePluginBase/MoEngagePluginUtils.swift
+++ b/Sources/MoEngagePluginBase/MoEngagePluginUtils.swift
@@ -105,26 +105,26 @@ public class MoEngagePluginUtils {
         if let dataPayload = payload[MoEngagePluginConstants.General.data] as? [String: Any], let position = dataPayload[MoEngagePluginConstants.InApp.position] as? String {
             switch position {
             case MoEngagePluginConstants.InApp.NudgePosition.top.rawValue:
-                return NudgePositionTop
+                return .top
             case MoEngagePluginConstants.InApp.NudgePosition.bottom.rawValue:
-                return NudgePositionBottom
+                return .bottom
             case MoEngagePluginConstants.InApp.NudgePosition.bottomLeft.rawValue:
-                return NudgePositionBottomLeft
+                return .bottomLeft
             case MoEngagePluginConstants.InApp.NudgePosition.bottomRight.rawValue:
-                return NudgePositionBottomRight
+                return .bottomRight
             default:
-                return NudgePositionAny
+                return .any
             }
         }
-        return NudgePositionNone
+        return .none
     }
     
     static func getInAppActionType(inappAction: MoEngageInAppAction) -> String? {
         var actionType: String? = nil
         
-        if inappAction.actionType == CustomAction {
+        if inappAction.actionType == .customAction {
             actionType = MoEngagePluginConstants.InApp.customAction
-        } else if inappAction.actionType == NavigationAction {
+        } else if inappAction.actionType == .navigationAction {
             actionType =  MoEngagePluginConstants.General.navigation
         }
         

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "MoEngagePluginBase",
   "postBuild": "Utilities/post_build.rb",
-  "sdkVerMin": "10.14.0",
+  "sdkVerMin": "11.00.0",
   "packages": [
     {
       "name": "MoEngagePluginBase",


### PR DESCRIPTION
#Jira
https://moengagetrial.atlassian.net/browse/MOEN-46340

## Changes
Adapts MoEngagePluginBase to the MoEngage iOS SDK **11.0.0** major release (Swift-6 / concurrency migration).

- InApp enum case renames: `MoEngageNudgePosition` → `.top/.bottom/.bottomLeft/.bottomRight/.any/.none`; `MoEngageInAppActionType` → `.customAction/.navigationAction`.
- `MoEngageModule.Item` conformance updated to the SDK-11 actor-isolated protocol (isolated `MoEngageSDKInstance`, optional `Info`, added `process(AsyncEvent) async` + `listensToAdditionalNotifications()`).
- Auth-error listener made `@MainActor` and instantiated on the main actor (SDK's `MoEngageAuthenticationError.Listener` is now `@MainActor`).
- Info.plist config fetch migrated `MoEngageInitialization` → `MoEngageConfig.FileBased` (+ `asSdkConfig`); PluginBase public API unchanged.
- Bumped `apple-sdk` SPM pin + `sdkVerMin` to 11.00.0; CHANGELOG entry (`[minor]` feature + `[major]` SDK line).

### Verification
- Builds green: iOS Debug/Release + tvOS Debug/Release against **published SDK 11.00.0**.
- Unit tests pass.
- Runtime smoke test on simulator: SDK init + module lifecycle (Core config sync, InApp v8 campaigns, Inbox) confirmed.

### Pending
- Final version bump (major vs minor) resolved at release time (`## Release Version` placeholder; `[major]` SDK line drives it).